### PR TITLE
Fix loop using wrong array's size

### DIFF
--- a/addons/sourcemod/scripting/navmesh.sp
+++ b/addons/sourcemod/scripting/navmesh.sp
@@ -1700,7 +1700,7 @@ bool NavMeshLoad(const char[] sMapName)
 	
 	if (g_hNavMeshAreaEncounterSpots.Length > 0)
 	{
-		for (int iIndex = 0, iSize = g_hNavMeshAreaEncounterPaths.Length; iIndex < iSize; iIndex++)
+		for (int iIndex = 0, iSize = g_hNavMeshAreaEncounterSpots.Length; iIndex < iSize; iIndex++)
 		{
 			int id = g_hNavMeshAreaEncounterSpots.Get(iIndex, NavMeshEncounterSpot_HidingSpotIndex);
 			g_hNavMeshAreaEncounterSpots.Set(iIndex, NavMeshFindHidingSpotByID(id), NavMeshEncounterSpot_HidingSpotIndex);


### PR DESCRIPTION
Seems like this loop was using the wrong ArrayList's size when iterating in initialization.

Caused this exception on startup for me:

```
L 09/18/2020 - 14:21:14: [navmesh.smx] Found .NAV file in maps\workshop/1685313095/mg_gradient.nav
L 09/18/2020 - 14:21:14: [navmesh.smx] Is mesh analyzed: 1
L 09/18/2020 - 14:21:14: [navmesh.smx] Nav version: 16; SubVersion: 1 (v10+); BSPSize: 5894896; MagicNumber: -17958194
L 09/18/2020 - 14:21:14: [navmesh.smx] Place count: 0
L 09/18/2020 - 14:21:14: [navmesh.smx] Has unnamed areas: true
L 09/18/2020 - 14:21:14: [navmesh.smx] Area count: 2840
L 09/18/2020 - 14:21:16: [navmesh.smx] Parsed 2840 areas in 2.852231 seconds.
L 09/18/2020 - 14:21:16: [navmesh.smx] Ladder count: 0
L 09/18/2020 - 14:21:16: [SM] Exception reported: Invalid index 38513 (count: 38513)
L 09/18/2020 - 14:21:16: [SM] Blaming: navmesh.smx
L 09/18/2020 - 14:21:16: [SM] Call stack trace:
L 09/18/2020 - 14:21:17: [SM]   [0] ArrayList.Get
L 09/18/2020 - 14:21:17: [SM]   [1] Line 1705, c:\srcds\csgo\addons\sourcemod\scripting\navmesh.sp::NavMeshLoad
L 09/18/2020 - 14:21:17: [SM]   [2] Line 396, c:\srcds\csgo\addons\sourcemod\scripting\navmesh.sp::OnMapStart